### PR TITLE
chore: improve treesitter queries

### DIFF
--- a/doc_comments_ai/treesitter/treesitter.py
+++ b/doc_comments_ai/treesitter/treesitter.py
@@ -38,27 +38,26 @@ class Treesitter(ABC):
         result = []
         methods.reverse()
         while methods:
-
-            def process_method(doc_comment):
-                if methods[-1][1] == "method":
-                    method = methods.pop()
-                    if methods[-1][1] == "method_name":
-                        method_name = methods.pop()
-                        result.append(
-                            TreesitterMethodNode(
-                                method_name[0].text.decode(),
-                                doc_comment[0].text.decode() if doc_comment else None,
-                                method[0],
-                            )
-                        )
-
-            if methods[-1][1] == "block_comment":
+            if methods and methods[-1][1] == "doc_comment":
                 doc_comment = methods.pop()
-                process_method(doc_comment)
+                self.process_method(methods, doc_comment, result)
             else:
-                process_method(None)
+                self.process_method(methods, None, result)
 
         return result
+
+    def process_method(self, methods, doc_comment, result):
+        if methods and methods[-1][1] == "method":
+            method = methods.pop()
+            if methods and methods[-1][1] == "method_name":
+                method_name = methods.pop()
+                result.append(
+                    TreesitterMethodNode(
+                        method_name[0].text.decode(),
+                        doc_comment[0].text.decode() if doc_comment else None,
+                        method[0],
+                    )
+                )
 
     @abstractmethod
     def _query_all_methods(self):

--- a/doc_comments_ai/treesitter/treesitter.py
+++ b/doc_comments_ai/treesitter/treesitter.py
@@ -34,6 +34,32 @@ class Treesitter(ABC):
         self.tree = self.parser.parse(file_bytes)
         pass
 
+    def parse_methods(self, methods: list[tuple[tree_sitter.Node, str]]):
+        result = []
+        methods.reverse()
+        while methods:
+
+            def process_method(doc_comment):
+                if methods[-1][1] == "method":
+                    method = methods.pop()
+                    if methods[-1][1] == "method_name":
+                        method_name = methods.pop()
+                        result.append(
+                            TreesitterMethodNode(
+                                method_name[0].text.decode(),
+                                doc_comment[0].text.decode() if doc_comment else None,
+                                method[0],
+                            )
+                        )
+
+            if methods[-1][1] == "block_comment":
+                doc_comment = methods.pop()
+                process_method(doc_comment)
+            else:
+                process_method(None)
+
+        return result
+
     @abstractmethod
     def _query_all_methods(self):
         """

--- a/doc_comments_ai/treesitter/treesitter.py
+++ b/doc_comments_ai/treesitter/treesitter.py
@@ -41,10 +41,3 @@ class Treesitter(ABC):
         based on the language
         """
         pass
-
-    @abstractmethod
-    def _query_method_name(self, node: tree_sitter.Node):
-        """
-        This function returns the name of a method node
-        """
-        pass

--- a/doc_comments_ai/treesitter/treesitter_go.py
+++ b/doc_comments_ai/treesitter/treesitter_go.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -11,34 +12,17 @@ class TreesitterGo(Treesitter):
 
     def parse(self, file_bytes: bytes) -> list[TreesitterMethodNode]:
         super().parse(file_bytes)
-        result = []
         methods = self._query_all_methods(self.tree.root_node)
-        for method in methods:
-            method_name = self._query_method_name(method["method"])
-            doc_comment = method["doc_comment"]
-            result.append(
-                TreesitterMethodNode(method_name, doc_comment, method["method"])
-            )
-        return result
-
-    def _query_method_name(self, node: tree_sitter.Node):
-        if node.type == "function_declaration":
-            for child in node.children:
-                if child.type == "identifier":
-                    return child.text.decode()
-        return None
+        return self.parse_methods(methods)
 
     def _query_all_methods(self, node: tree_sitter.Node):
-        methods = []
-        if node.type == "function_declaration":
-            doc_comment_node = None
-            if node.prev_named_sibling and node.prev_named_sibling.type == "comment":
-                doc_comment_node = node.prev_named_sibling.text.decode()
-            methods.append({"method": node, "doc_comment": doc_comment_node})
-        else:
-            for child in node.children:
-                methods.extend(self._query_all_methods(child))
-        return methods
+        query_code = """
+        (comment) @doc_comment
+        (function_declaration
+            name: (identifier) @method_name) @method
+        """
+        query = self.language.query(query_code)
+        return query.captures(node)
 
 
 # Register the TreesitterJava class in the registry

--- a/doc_comments_ai/treesitter/treesitter_java.py
+++ b/doc_comments_ai/treesitter/treesitter_java.py
@@ -17,7 +17,7 @@ class TreesitterJava(Treesitter):
 
     def _query_all_methods(self, node: tree_sitter.Node):
         query_code = """
-        (block_comment) @block_comment
+        (block_comment) @doc_comment
         (method_declaration
             name: (identifier) @method_name) @method
         """

--- a/doc_comments_ai/treesitter/treesitter_java.py
+++ b/doc_comments_ai/treesitter/treesitter_java.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -11,37 +12,17 @@ class TreesitterJava(Treesitter):
 
     def parse(self, file_bytes: bytes) -> list[TreesitterMethodNode]:
         super().parse(file_bytes)
-        result = []
         methods = self._query_all_methods(self.tree.root_node)
-        for method in methods:
-            method_name = self._query_method_name(method["method"])
-            doc_comment = method["doc_comment"]
-            result.append(
-                TreesitterMethodNode(method_name, doc_comment, method["method"])
-            )
-        return result
-
-    def _query_method_name(self, node: tree_sitter.Node):
-        if node.type == "method_declaration":
-            for child in node.children:
-                if child.type == "identifier":
-                    return child.text.decode()
-        return None
+        return self.parse_methods(methods)
 
     def _query_all_methods(self, node: tree_sitter.Node):
-        methods = []
-        if node.type == "method_declaration":
-            doc_comment_node = None
-            if (
-                node.prev_named_sibling
-                and node.prev_named_sibling.type == "block_comment"
-            ):
-                doc_comment_node = node.prev_named_sibling.text.decode()
-            methods.append({"method": node, "doc_comment": doc_comment_node})
-        else:
-            for child in node.children:
-                methods.extend(self._query_all_methods(child))
-        return methods
+        query_code = """
+        (block_comment) @block_comment
+        (method_declaration
+            name: (identifier) @method_name) @method
+        """
+        query = self.language.query(query_code)
+        return query.captures(node)
 
 
 # Register the TreesitterJava class in the registry

--- a/doc_comments_ai/treesitter/treesitter_js.py
+++ b/doc_comments_ai/treesitter/treesitter_js.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -11,34 +12,17 @@ class TreesitterJavascript(Treesitter):
 
     def parse(self, file_bytes: bytes) -> list[TreesitterMethodNode]:
         super().parse(file_bytes)
-        result = []
         methods = self._query_all_methods(self.tree.root_node)
-        for method in methods:
-            method_name = self._query_method_name(method["method"])
-            doc_comment = method["doc_comment"]
-            result.append(
-                TreesitterMethodNode(method_name, doc_comment, method["method"])
-            )
-        return result
-
-    def _query_method_name(self, node: tree_sitter.Node):
-        if node.type == "function_declaration":
-            for child in node.children:
-                if child.type == "identifier":
-                    return child.text.decode()
-        return None
+        return self.parse_methods(methods)
 
     def _query_all_methods(self, node: tree_sitter.Node):
-        methods = []
-        if node.type == "function_declaration":
-            doc_comment_node = None
-            if node.prev_named_sibling and node.prev_named_sibling.type == "comment":
-                doc_comment_node = node.prev_named_sibling.text.decode()
-            methods.append({"method": node, "doc_comment": doc_comment_node})
-        else:
-            for child in node.children:
-                methods.extend(self._query_all_methods(child))
-        return methods
+        query_code = """
+        (comment) @doc_comment
+        (function_declaration
+            name: (identifier) @method_name) @method
+        """
+        query = self.language.query(query_code)
+        return query.captures(node)
 
 
 # Register the TreesitterJava class in the registry

--- a/doc_comments_ai/treesitter/treesitter_kt.py
+++ b/doc_comments_ai/treesitter/treesitter_kt.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -11,34 +12,17 @@ class TreesitterKotlin(Treesitter):
 
     def parse(self, file_bytes: bytes) -> list[TreesitterMethodNode]:
         super().parse(file_bytes)
-        result = []
         methods = self._query_all_methods(self.tree.root_node)
-        for method in methods:
-            method_name = self._query_method_name(method["method"])
-            doc_comment = method["doc_comment"]
-            result.append(
-                TreesitterMethodNode(method_name, doc_comment, method["method"])
-            )
-        return result
-
-    def _query_method_name(self, node: tree_sitter.Node):
-        if node.type == "function_declaration":
-            for child in node.children:
-                if child.type == "simple_identifier":
-                    return child.text.decode()
-        return None
+        return self.parse_methods(methods)
 
     def _query_all_methods(self, node: tree_sitter.Node):
-        methods = []
-        if node.type == "function_declaration":
-            doc_comment_node = None
-            if node.prev_named_sibling and node.prev_named_sibling.type == "comment":
-                doc_comment_node = node.prev_named_sibling.text.decode()
-            methods.append({"method": node, "doc_comment": doc_comment_node})
-        else:
-            for child in node.children:
-                methods.extend(self._query_all_methods(child))
-        return methods
+        query_code = """
+        (comment) @doc_comment
+        (function_declaration
+            (simple_identifier) @method_name) @method
+        """
+        query = self.language.query(query_code)
+        return query.captures(node)
 
 
 # Register the TreesitterJava class in the registry

--- a/doc_comments_ai/treesitter/treesitter_py.py
+++ b/doc_comments_ai/treesitter/treesitter_py.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -13,15 +14,15 @@ class TreesitterPython(Treesitter):
         super().parse(file_bytes)
         result = []
         methods = self._query_all_methods(self.tree.root_node)
-        # methods is a list of tuples of the form (method_name, method_body)
-        for i in range(0, len(methods), 2):
-            method_body = methods[i][0]
-            method_name = methods[i + 1][0].text.decode()
-            doc_str_node = self._query_doc_comment(method_body)
-            doc_comment = None
-            if doc_str_node:
-                doc_comment = doc_str_node[0][0].text.decode()
-            result.append(TreesitterMethodNode(method_name, doc_comment, method_body))
+        methods.reverse()
+        while methods:
+            if methods and methods[-1][1] == "method":
+                doc_comment = self._query_doc_comment(methods[-1][0])
+                if doc_comment:
+                    self.process_method(methods, doc_comment[0], result)
+                else:
+                    self.process_method(methods, None, result)
+
         return result
 
     def _query_all_methods(self, node: tree_sitter.Node):

--- a/doc_comments_ai/treesitter/treesitter_py.py
+++ b/doc_comments_ai/treesitter/treesitter_py.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -13,47 +14,30 @@ class TreesitterPython(Treesitter):
         super().parse(file_bytes)
         result = []
         methods = self._query_all_methods(self.tree.root_node)
-        for method in methods:
-            method_name = self._query_method_name(method)
-            doc_comment = self._query_doc_comment(method)
-            result.append(TreesitterMethodNode(method_name, doc_comment, method))
+        # methods is a list of tuples of the form (method_name, method_body)
+        for i in range(0, len(methods), 2):
+            method_name = methods[i][0].text.decode()
+            method_body = methods[i + 1][0]
+            doc_str_node = self._query_doc_comment(method_body)
+            doc_comment = None
+            if doc_str_node:
+                doc_comment = doc_str_node[0][0].text.decode()
+            result.append(TreesitterMethodNode(method_name, doc_comment, method_body))
         return result
 
-    def _query_method_name(self, node: tree_sitter.Node):
-        if node.type == "function_definition":
-            for child in node.children:
-                if child.type == "identifier":
-                    return child.text.decode()
-        return None
-
     def _query_all_methods(self, node: tree_sitter.Node):
-        methods = []
-        for child in node.children:
-            if child.type == "function_definition":
-                methods.append(child)
-        return methods
+        query_code = """
+        (function_definition
+            name: (identifier) @method_name
+            body: (block) @method_body)
+        """
+        query = self.language.query(query_code)
+        return query.captures(node)
 
     def _query_doc_comment(self, node: tree_sitter.Node):
-        """
-        This function returns a treesitter query for doc comments
-        based on the language
-        """
-        query_code = """
-            (module . (comment)* . (expression_statement (string)) @module_doc_str)
-
-            (class_definition
-                body: (block . (expression_statement (string)) @class_doc_str))
-
-            (function_definition
-                body: (block . (expression_statement (string)) @function_doc_str))
-        """
-        doc_str_query = self.language.query(query_code)
-        doc_strs = doc_str_query.captures(node)
-
-        if doc_strs:
-            return doc_strs[0][0].text.decode()
-        else:
-            return None
+        query_code = "(block . (expression_statement (string)) @doc_str)"
+        query = self.language.query(query_code)
+        return query.captures(node)
 
 
 # Register the TreesitterPython class in the registry

--- a/doc_comments_ai/treesitter/treesitter_py.py
+++ b/doc_comments_ai/treesitter/treesitter_py.py
@@ -1,8 +1,7 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import (Treesitter,
-                                                   TreesitterMethodNode)
+from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -16,8 +15,8 @@ class TreesitterPython(Treesitter):
         methods = self._query_all_methods(self.tree.root_node)
         # methods is a list of tuples of the form (method_name, method_body)
         for i in range(0, len(methods), 2):
-            method_name = methods[i][0].text.decode()
-            method_body = methods[i + 1][0]
+            method_body = methods[i][0]
+            method_name = methods[i + 1][0].text.decode()
             doc_str_node = self._query_doc_comment(method_body)
             doc_comment = None
             if doc_str_node:
@@ -28,8 +27,7 @@ class TreesitterPython(Treesitter):
     def _query_all_methods(self, node: tree_sitter.Node):
         query_code = """
         (function_definition
-            name: (identifier) @method_name
-            body: (block) @method_body)
+            name: (identifier) @method_name) @method
         """
         query = self.language.query(query_code)
         return query.captures(node)

--- a/doc_comments_ai/treesitter/treesitter_rs.py
+++ b/doc_comments_ai/treesitter/treesitter_rs.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 

--- a/doc_comments_ai/treesitter/treesitter_ts.py
+++ b/doc_comments_ai/treesitter/treesitter_ts.py
@@ -1,7 +1,8 @@
 import tree_sitter
 
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 from doc_comments_ai.treesitter.treesitter_registry import TreesitterRegistry
 
 
@@ -11,34 +12,17 @@ class TreesitterTypescript(Treesitter):
 
     def parse(self, file_bytes: bytes) -> list[TreesitterMethodNode]:
         super().parse(file_bytes)
-        result = []
         methods = self._query_all_methods(self.tree.root_node)
-        for method in methods:
-            method_name = self._query_method_name(method["method"])
-            doc_comment = method["doc_comment"]
-            result.append(
-                TreesitterMethodNode(method_name, doc_comment, method["method"])
-            )
-        return result
-
-    def _query_method_name(self, node: tree_sitter.Node):
-        if node.type == "function_declaration":
-            for child in node.children:
-                if child.type == "identifier":
-                    return child.text.decode()
-        return None
+        return self.parse_methods(methods)
 
     def _query_all_methods(self, node: tree_sitter.Node):
-        methods = []
-        if node.type == "function_declaration":
-            doc_comment_node = None
-            if node.prev_named_sibling and node.prev_named_sibling.type == "comment":
-                doc_comment_node = node.prev_named_sibling.text.decode()
-            methods.append({"method": node, "doc_comment": doc_comment_node})
-        else:
-            for child in node.children:
-                methods.extend(self._query_all_methods(child))
-        return methods
+        query_code = """
+        (comment) @doc_comment
+        (function_declaration
+            name: (identifier) @method_name) @method
+        """
+        query = self.language.query(query_code)
+        return query.captures(node)
 
 
 # Register the TreesitterJava class in the registry

--- a/tests/treesitter_query_test.py
+++ b/tests/treesitter_query_test.py
@@ -36,7 +36,8 @@ def test_python_qery(python_code_fixture):
 
     assert (
         treesitterNodes[0].method_source_code
-        == """\"\"\"
+        == """def get_programming_language(file_extension: str) -> Language:
+    \"\"\"
     Returns the corresponding programming language based on the given file extension.
 
     Args:
@@ -81,6 +82,21 @@ def test_java_qery(java_code_fixture):
     )
 
     assert treesitterNodes[1].doc_comment is None
+
+    assert (
+        treesitterNodes[0].method_source_code
+        == """public static Language getProgrammingLanguage(String fileExtension) {
+        Map<String, Language> languageMapping = new HashMap<>();
+        languageMapping.put(".py", Language.PYTHON);
+        languageMapping.put(".js", Language.JAVASCRIPT);
+        languageMapping.put(".ts", Language.TYPESCRIPT);
+        languageMapping.put(".java", Language.JAVA);
+        languageMapping.put(".kt", Language.KOTLIN);
+        languageMapping.put(".lua", Language.LUA);
+
+        return languageMapping.getOrDefault(fileExtension, Language.UNKNOWN);
+    }"""
+    )
 
 
 @pytest.mark.usefixtures("javascript_code_fixture")

--- a/tests/treesitter_query_test.py
+++ b/tests/treesitter_query_test.py
@@ -124,6 +124,22 @@ def test_javascript_qery(javascript_code_fixture):
 
     assert treesitterNodes[1].doc_comment is None
 
+    assert (
+        treesitterNodes[0].method_source_code
+        == """function getProgrammingLanguage(fileExtension) {
+    const languageMapping = {
+        ".py": Language.PYTHON,
+        ".js": Language.JAVASCRIPT,
+        ".ts": Language.TYPESCRIPT,
+        ".java": Language.JAVA,
+        ".kt": Language.KOTLIN,
+        ".lua": Language.LUA,
+    };
+
+    return languageMapping[fileExtension] || Language.UNKNOWN;
+}"""
+    )
+
 
 @pytest.mark.usefixtures("typescript_code_fixture")
 def test_typescript_qery(typescript_code_fixture):
@@ -149,6 +165,22 @@ def test_typescript_qery(typescript_code_fixture):
     )
 
     assert treesitterNodes[1].doc_comment is None
+
+    assert (
+        treesitterNodes[0].method_source_code
+        == """function getProgrammingLanguage(fileExtension: string): Language {
+    const languageMapping: { [key: string]: Language } = {
+        ".py": Language.PYTHON,
+        ".js": Language.JAVASCRIPT,
+        ".ts": Language.TYPESCRIPT,
+        ".java": Language.JAVA,
+        ".kt": Language.KOTLIN,
+        ".lua": Language.LUA,
+    };
+
+    return languageMapping[fileExtension] || Language.UNKNOWN;
+}"""
+    )
 
 
 @pytest.mark.usefixtures("rust_code_fixture")
@@ -187,6 +219,25 @@ def test_rust_qery(rust_code_fixture):
 
     assert treesitterNodes[1].doc_comment is None
 
+    assert (
+        treesitterNodes[0].method_source_code
+        == """fn get_programming_language(file_extension: &str) -> Language {
+    let language_mapping: std::collections::HashMap<&str, Language> = [
+        (".py", Language::PYTHON),
+        (".js", Language::JAVASCRIPT),
+        (".ts", Language::TYPESCRIPT),
+        (".java", Language::JAVA),
+        (".kt", Language::KOTLIN),
+        (".lua", Language::LUA),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    *language_mapping.get(file_extension).unwrap_or(&Language::UNKNOWN)
+}"""
+    )
+
 
 @pytest.mark.usefixtures("kotlin_code_fixture")
 def test_kotlin_qery(kotlin_code_fixture):
@@ -211,6 +262,23 @@ def test_kotlin_qery(kotlin_code_fixture):
  */"""
     )
 
+    assert treesitterNodes[1].doc_comment is None
+
+    assert (
+        treesitterNodes[0].method_source_code
+        == """fun getProgrammingLanguage(fileExtension: String): Language {
+    val languageMapping = HashMap<String, Language>()
+    languageMapping[".py"] = Language.PYTHON
+    languageMapping[".js"] = Language.JAVASCRIPT
+    languageMapping[".ts"] = Language.TYPESCRIPT
+    languageMapping[".java"] = Language.JAVA
+    languageMapping[".kt"] = Language.KOTLIN
+    languageMapping[".lua"] = Language.LUA
+
+    return languageMapping.getOrDefault(fileExtension, Language.UNKNOWN)
+}"""
+    )
+
 
 @pytest.mark.usefixtures("go_code_fixture")
 def test_go_qery(go_code_fixture):
@@ -231,3 +299,23 @@ def test_go_qery(go_code_fixture):
     )
 
     assert treesitterNodes[1].doc_comment is None
+
+    assert (
+        treesitterNodes[0].method_source_code
+        == """func getProgrammingLanguage(fileExtension string) Language {
+	languageMapping := map[string]Language{
+		".py":     PYTHON,
+		".js":     JAVASCRIPT,
+		".ts":     TYPESCRIPT,
+		".java":   JAVA,
+		".kt":     KOTLIN,
+		".lua":    LUA,
+	}
+
+	language, exists := languageMapping[fileExtension]
+	if exists {
+		return language
+	}
+	return UNKNOWN
+}"""
+    )

--- a/tests/treesitter_query_test.py
+++ b/tests/treesitter_query_test.py
@@ -2,7 +2,8 @@ import pytest
 
 from doc_comments_ai import domain
 from doc_comments_ai.constants import Language
-from doc_comments_ai.treesitter.treesitter import Treesitter, TreesitterMethodNode
+from doc_comments_ai.treesitter.treesitter import (Treesitter,
+                                                   TreesitterMethodNode)
 
 
 @pytest.mark.usefixtures("python_code_fixture")
@@ -32,6 +33,28 @@ def test_python_qery(python_code_fixture):
     )
 
     assert treesitterNodes[1].doc_comment is None
+
+    assert (
+        treesitterNodes[0].method_source_code
+        == """\"\"\"
+    Returns the corresponding programming language based on the given file extension.
+
+    Args:
+        file_extension (str): The file extension of the programming file.
+
+    Returns:
+        Language: The corresponding programming language if it exists in the mapping, otherwise Language.UNKNOWN.
+    \"\"\"
+    language_mapping = {
+        ".py": Language.PYTHON,
+        ".js": Language.JAVASCRIPT,
+        ".ts": Language.TYPESCRIPT,
+        ".java": Language.JAVA,
+        ".kt": Language.KOTLIN,
+        ".lua": Language.LUA,
+    }
+    return language_mapping.get(file_extension, Language.UNKNOWN)"""
+    )
 
 
 @pytest.mark.usefixtures("java_code_fixture")


### PR DESCRIPTION
Currently the method bodies, definitions and doc-comments are extract by iterating the AST. Better solution is to query all methods with definition, body and doc-comment at once. 
Python is straightforward, since the doc-string is inside of the method body.
Languages where the doc strings resides outside of the method body, e.g. once before the method definition as in most languages, the method must be queried together with its previous sibling.